### PR TITLE
support to change VESA/VBE mode in vesafb command for VESA/VBE

### DIFF
--- a/core/ipxe/src/arch/x86/hci/commands/vesa_cmd.c
+++ b/core/ipxe/src/arch/x86/hci/commands/vesa_cmd.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2016 Byeoungwook Kim <quddnr145@gmail.com>.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * You can also choose to distribute this program under the terms of
+ * the Unmodified Binary Distribution Licence (as given in the file
+ * COPYING.UBDL), provided that you have satisfied its requirements.
+ */
+
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+#include <stdint.h>
+#include <stdio.h>
+#include <errno.h>
+#include <getopt.h>
+#include <ipxe/vesafb.h>
+#include <ipxe/command.h>
+#include <ipxe/parseopt.h>
+
+/** @file
+ *
+ * x86 VESA feature detection command
+ *
+ */
+
+/** "vesa" options */
+struct vesa_options {};
+
+/** "vesa" option list */
+static struct option_descriptor vesa_opts[] = {};
+
+/** "vesa" command descriptor */
+static struct command_descriptor vesa_cmd =
+	COMMAND_DESC ( struct vesa_options, vesa_opts, 0, 0, NULL );
+
+/**
+ * The "vesa" command
+ *
+ * @v argc              Argument count
+ * @v argv              Argument list
+ * @ret rc              Return status code
+ */
+static int vesa_exec ( int argc __unused, char **argv __unused ) {
+	struct vesa_options opts;
+	int rc;
+
+	/* Parse options */
+	if ( ( rc = parse_options ( argc, argv, &vesa_cmd, &opts ) ) != 0 )
+		return rc;
+
+        return 0;
+}
+
+/** x86 CPU feature detection command */
+struct command vesa_command __command = {
+        .name = "vesa",
+        .exec = vesa_exec,
+};

--- a/core/ipxe/src/arch/x86/interface/pcbios/vesafb.c
+++ b/core/ipxe/src/arch/x86/interface/pcbios/vesafb.c
@@ -528,6 +528,9 @@ static int vesafb_configure ( struct console_configuration *config ) {
 	if ( config->pixbuf )
 		ansicol_set_magic_transparent();
 
+	/* vesa/vga mode info */
+	config->data = (unsigned int)&vbe_buf;
+
 	return 0;
 }
 

--- a/core/ipxe/src/arch/x86/transitions/librm.S
+++ b/core/ipxe/src/arch/x86/transitions/librm.S
@@ -10,6 +10,8 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL )
 /* Drag in local definitions */
 #include "librm.h"
 
+#define SCREENINFO_ADDR 0x9000
+
 /* CR0: protection enabled */
 #define CR0_PE ( 1 << 0 )
 
@@ -326,6 +328,39 @@ set_seg_base:
 	movb	%al, 4(%bx)
 	movb	%ah, 7(%bx)
 	roll	$16, %eax
+	ret
+
+/****************************************************************************
+ * get vga card information for struct screeninfo
+ * used interrupt 0x10
+ * VBE status :
+ * AL == 4Fh: Function is supported
+ * AL != 4Fh: Function is not supported
+ * AH == 00h: Function call successful
+ * AH == 01h: Function call failed
+ * AH == 02h: Software supports this function, but the hardware does not
+ * AH == 03h: Function call invalid in current video mode
+ *
+ ****************************************************************************
+ */ 
+	.section ".text16.init_librm_vgamode", "ax", @progbits
+	.code16
+	.globl init_librm_vgamode
+init_librm_vgamode:
+	pushl	%eax
+	pushl	%edi
+
+	/* Change VgaMode & get struct screeninfo in vga.h */
+	/* setting struct screeninfo pointer */
+	movw	$SCREENINFO_ADDR, %di
+	movw	$0x4F00, %ax
+	int	$0x10
+
+	cmpb	$0x00, %ah
+	jne	1f
+
+1:	popl	%edi
+	popl	%eax
 	ret
 
 /****************************************************************************

--- a/core/ipxe/src/config/config.c
+++ b/core/ipxe/src/config/config.c
@@ -236,6 +236,9 @@ REQUIRE_OBJECT ( digest_cmd );
 #ifdef PXE_CMD
 REQUIRE_OBJECT ( pxe_cmd );
 #endif
+#ifdef VESA_CMD
+REQUEST_OBJECT ( vesa_cmd );
+#endif
 #ifdef LOTEST_CMD
 REQUIRE_OBJECT ( lotest_cmd );
 #endif

--- a/core/ipxe/src/config/config_usb.c
+++ b/core/ipxe/src/config/config_usb.c
@@ -60,3 +60,10 @@ REQUIRE_OBJECT ( usbkbd );
 #ifdef USB_EFI
 REQUIRE_OBJECT ( efi_usb );
 #endif
+
+#ifdef CONSOLE_VESAFB
+REQUIRE_OBJECT ( vesafb );
+#endif
+#ifdef CONSOLE_FRAMEBUFFER
+REQUIRE_OBJECT ( vesafb );
+#endif

--- a/core/ipxe/src/config/console.h
+++ b/core/ipxe/src/config/console.h
@@ -35,7 +35,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  */
 
 //#define	CONSOLE_SERIAL		/* Serial port console */
-//#define	CONSOLE_FRAMEBUFFER	/* Graphical framebuffer console */
+#define	CONSOLE_FRAMEBUFFER	/* Graphical framebuffer console */
 //#define	CONSOLE_SYSLOG		/* Syslog console */
 //#define	CONSOLE_SYSLOGS		/* Encrypted syslog console */
 //#define	CONSOLE_VMWARE		/* VMware logfile console */

--- a/core/ipxe/src/config/general.h
+++ b/core/ipxe/src/config/general.h
@@ -109,7 +109,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 //#define	IMAGE_EFI		/* EFI image support */
 //#define	IMAGE_SDI		/* SDI image support */
 //#define	IMAGE_PNM		/* PNM image support */
-//#define	IMAGE_PNG		/* PNG image support */
+#define	IMAGE_PNG		/* PNG image support */
 
 /*
  * Command-line commands to include
@@ -145,6 +145,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define CONSOLE_CMD		/* Console command */
 #define IPSTAT_CMD		/* IP statistics commands */
 #define PROFSTAT_CMD		/* Profiling commands */
+#define VESA_CMD
 
 /*
  * ROM-specific options

--- a/core/ipxe/src/config/general.h
+++ b/core/ipxe/src/config/general.h
@@ -43,8 +43,8 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
  * PXE support
  *
  */
-//#undef	PXE_STACK		/* PXE stack in iPXE - you want this! */
-//#undef	PXE_MENU		/* PXE menu booting */
+#undef	PXE_STACK		/* PXE stack in iPXE - you want this! */
+#undef	PXE_MENU		/* PXE menu booting */
 
 /*
  * Download protocols
@@ -129,22 +129,22 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define MENU_CMD		/* Menu commands */
 #define LOGIN_CMD		/* Login command */
 #define SYNC_CMD		/* Sync command */
-//#define NSLOOKUP_CMD		/* DNS resolving command */
-//#define TIME_CMD		/* Time commands */
-//#define DIGEST_CMD		/* Image crypto digest commands */
-//#define LOTEST_CMD		/* Loopback testing commands */
-//#define VLAN_CMD		/* VLAN commands */
-//#define PXE_CMD		/* PXE commands */
-//#define REBOOT_CMD		/* Reboot command */
-//#define POWEROFF_CMD		/* Power off command */
-//#define IMAGE_TRUST_CMD	/* Image trust management commands */
-//#define PCI_CMD		/* PCI commands */
-//#define PARAM_CMD		/* Form parameter commands */
-//#define NEIGHBOUR_CMD		/* Neighbour management commands */
-//#define PING_CMD		/* Ping command */
-//#define CONSOLE_CMD		/* Console command */
-//#define IPSTAT_CMD		/* IP statistics commands */
-//#define PROFSTAT_CMD		/* Profiling commands */
+#define NSLOOKUP_CMD		/* DNS resolving command */
+#define TIME_CMD		/* Time commands */
+#define DIGEST_CMD		/* Image crypto digest commands */
+#define LOTEST_CMD		/* Loopback testing commands */
+#define VLAN_CMD		/* VLAN commands */
+#define PXE_CMD		/* PXE commands */
+#define REBOOT_CMD		/* Reboot command */
+#define POWEROFF_CMD		/* Power off command */
+#define IMAGE_TRUST_CMD	/* Image trust management commands */
+#define PCI_CMD		/* PCI commands */
+#define PARAM_CMD		/* Form parameter commands */
+#define NEIGHBOUR_CMD		/* Neighbour management commands */
+#define PING_CMD		/* Ping command */
+#define CONSOLE_CMD		/* Console command */
+#define IPSTAT_CMD		/* IP statistics commands */
+#define PROFSTAT_CMD		/* Profiling commands */
 
 /*
  * ROM-specific options

--- a/core/ipxe/src/include/ipxe/console.h
+++ b/core/ipxe/src/include/ipxe/console.h
@@ -38,6 +38,8 @@ struct console_configuration {
 	unsigned int bottom;
 	/** Background picture, if any */
 	struct pixel_buffer *pixbuf;
+	/** Temp member */
+	unsigned int data;
 };
 
 /**


### PR DESCRIPTION
fixed #31  vesa/vga video control in custom visa driver

iPXE 에서 Custom Device Driver 제작을 통한 TextMode => VESA/VGA Mode 전환 작업
core/ipxe/src/arch/x86/hci/commands/vesa_cmd.c 참고

gui로 변경을 위한 `vesafb` 명령어 추가
이후의 vbe/vesa 작업 내역은 `feature/ipxe_vesa` branch 로 이전후 gui 제작을 위한 그래픽 library 지원예정

![virtualbox_ubuntu_15_03_2016_04_56_31](https://cloud.githubusercontent.com/assets/7445459/13758613/a323d7cc-ea6d-11e5-94ba-9af82b2a926a.png)
